### PR TITLE
Single-click Release Creation and Manifest Updates

### DIFF
--- a/.github/workflows/release-apworld.yaml
+++ b/.github/workflows/release-apworld.yaml
@@ -1,0 +1,71 @@
+name: Release AP World
+
+on: workflow_dispatch
+
+env:
+  AP_WORLD_NAME: Resident Evil 1 Remake
+  AP_WORLD_DIR: residentevil1remake
+  VERSION_NUM: "0.0.0"
+  VERSION_NUM_TEXT: 0.0.0
+  AP_WORLD_PATH: ""
+  AP_WORLD_YAML_PATH: ""
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout AP
+        uses: actions/checkout@v4
+        with:
+          repository: ArchipelagoMW/Archipelago
+          path: .
+      - name: Checkout this Repo
+        uses: actions/checkout@v4
+        with:
+          path: temp/
+      - name: Set version number env from apworld init
+        run: |
+          mkdir -p worlds/${AP_WORLD_DIR}
+          cp -R temp/${AP_WORLD_DIR}/* worlds/${AP_WORLD_DIR}
+          V_NUM=$(cat worlds/${AP_WORLD_DIR}/__init__.py | grep "apworld_release_version" | head -n1 | awk '{print $3}')
+          V_NUM_TEXT=$(echo $V_NUM | sed 's/"//g')
+          echo "VERSION_NUM=$V_NUM" >> $GITHUB_ENV
+          echo "VERSION_NUM_TEXT=$V_NUM_TEXT" >> $GITHUB_ENV
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '~3.12.7'
+          check-latest: true
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python ModuleUpdate.py --yes --force
+      - name: Update World Version in Manifest
+        run:  |
+          cd worlds/${{ env.AP_WORLD_DIR }}
+          echo -e "{\n\t\"game\": \"${{ env.AP_WORLD_NAME }}\"\n}" > archipelago.json
+          json="$(jq '.world_version = ${{ env.VERSION_NUM }}' archipelago.json)"
+          echo $json
+          echo "${json}" > archipelago.json
+      - name: Create AP World Archive 
+        run: |
+          python Launcher.py "Build APWorlds" -- "${{ env.AP_WORLD_NAME }}"
+          echo "AP_WORLD_PATH=build/apworlds/${{ env.AP_WORLD_DIR }}.apworld" >> $GITHUB_ENV
+      - name: Create AP World Template YAML
+        run: |
+          python Launcher.py "Generate Template Options"
+          echo "AP_WORLD_YAML_PATH=Players/Templates/${{ env.AP_WORLD_NAME }}.yaml" >> $GITHUB_ENV
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true  # don't publish right away
+          prerelease: false
+          name: ${{ env.AP_WORLD_NAME }} APWorld ${{ env.VERSION_NUM_TEXT }}
+          files: |
+            ${{ env.AP_WORLD_PATH }}
+            ${{ env.AP_WORLD_YAML_PATH }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Needed to update RE2R to have a manifest (in prep for an eventual AP 0.7.0) and wanted the world version in there, and made a GitHub Action to do it automatically at a button click... so figured I'd pass it along to all the other RE repos using the same style of apworld. 

(Credit to Tranquilite in the AP Discord, whose workflow I modified to work with these repos.)

**When you go to make a release, instead of manually zipping the apworld and all, you instead would:**
1. Click on the "Actions tab" in GitHub. (To the right of "Pull Requests".)
2. In the left column, click "Release AP World".
3. On the right side, click the "Run workflow" button, and then the green button that shows up.
4. Once it's done, go to the Releases page as normal and fill in the information for the draft release that was created.
    a. Don't forget to create a new tag as normal.
5. When you're done adding release notes and all to the draft release, click the Publish button as normal.

---

**Q: Why would I use this versus doing things manually?**
Every time you do a release, you would have to manually add/update the world version in the file if you wanted to take advantage of any AP versioning there. 

**Q: How is this different from running the "Build apworlds" action in AP's Launcher?**
It does exactly that (see line 55 of the workflow), except it adds in the world version automatically by pulling it from your apworld's init py.

**Q: Do I still have to zip the apworld as normal for a release?**
No, the workflow does that for you as well. It uses the folder in the main branch of this repo.

**Q: Why is there not an archipelago.json in this PR or in my repo?**
Not needed. The workflow creates a basic JSON with the game name and world version, then uses the "Build apworlds" action to do the rest, and it gets added to the apworld. So no need to maintain one in the repo.